### PR TITLE
Continuous Builds

### DIFF
--- a/dataserv_client/api.py
+++ b/dataserv_client/api.py
@@ -121,6 +121,6 @@ class Client(object):
         """TODO doc string"""
         self._ensure_address_given()
         bldr = builder.Builder(self.address, common.SHARD_SIZE, self.max_size)
-        hashes = bldr.build(self.store_path, debug=self.debug, cleanup=cleanup)
-        self._querry('/api/height/{0}/{1}'.format(self.address, len(hashes)))
-        return hashes
+        height = bldr.build(self.store_path, debug=self.debug, cleanup=cleanup)
+        self._querry('/api/height/{0}/{1}'.format(self.address, height))
+        return height

--- a/dataserv_client/builder.py
+++ b/dataserv_client/builder.py
@@ -37,14 +37,14 @@ class Builder:
             os.remove(path)
         return file_hash
 
-    def build(self, store_path, debug=False, cleanup=False):
+    def build(self, store_path, debug=False, cleanup=False, rebuild=False):
         """Fill the farmer with data up to their max."""
         for shard_num in range(int(self.max_size / self.shard_size)):
             seed = self.build_seed(shard_num)
             path = os.path.join(store_path, seed)
 
             # only generate if the file isn't there
-            if not os.path.exists(path):
+            if not os.path.exists(path) or rebuild:
                 file_hash = self.generate_shard(seed, store_path, cleanup)
 
                 if debug:

--- a/dataserv_client/builder.py
+++ b/dataserv_client/builder.py
@@ -39,18 +39,19 @@ class Builder:
 
     def build(self, store_path, debug=False, cleanup=False):
         """Fill the farmer with data up to their max."""
-        hashes = []
         for shard_num in range(int(self.max_size / self.shard_size)):
             seed = self.build_seed(shard_num)
-            file_hash = self.generate_shard(seed, store_path, cleanup)
-            hashes.append(file_hash)
+            path = os.path.join(store_path, seed)
 
-            if debug:
-                print("Saving seed {0} with SHA-256 hash {1}.".format(
-                    seed, file_hash
-                ))
+            # only generate if the file isn't there
+            if not os.path.exists(path):
+                file_hash = self.generate_shard(seed, store_path, cleanup)
 
-        return hashes
+                if debug:
+                    print("Saving seed {0} with SHA-256 hash {1}.".format(seed, file_hash))
+            else:
+                if debug:
+                    print("Skipping seed {0}. Already exists.".format(seed))
 
     def clean(self, store_path):
         """Delete shards from path."""

--- a/dataserv_client/builder.py
+++ b/dataserv_client/builder.py
@@ -39,7 +39,9 @@ class Builder:
 
     def build(self, store_path, debug=False, cleanup=False, rebuild=False):
         """Fill the farmer with data up to their max."""
-        for shard_num in range(int(self.max_size / self.shard_size)):
+        height = int(self.max_size / self.shard_size)
+
+        for shard_num in range(height):
             seed = self.build_seed(shard_num)
             path = os.path.join(store_path, seed)
 
@@ -52,6 +54,8 @@ class Builder:
             else:
                 if debug:
                     print("Skipping seed {0}. Already exists.".format(seed))
+
+        return height
 
     def clean(self, store_path):
         """Delete shards from path."""

--- a/setup.py
+++ b/setup.py
@@ -78,6 +78,7 @@ setup(
     install_requires=[
         'RandomIO == 0.2.1',
         'future == 0.15.0',  # for python 2.7 support
+        'partialhash == 1.1.0'
     ],
     tests_require=[
         'coverage',

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -113,3 +113,24 @@ class TestBuilder(unittest.TestCase):
 
         # clean command
         bucket.clean(self.my_store_path)
+
+    def test_build_rebuild(self):
+        # generate shards for testing
+        bucket = Builder(address_epsilon, my_shard_size, my_max_size)
+        bucket.build(self.my_store_path, False, False)
+
+        # remove one of the files
+        remove_file = 'baf428097fa601fac185750483fd532abb0e43f9f049398290fac2c049cc2a60'
+        os.remove(os.path.join(self.my_store_path, remove_file))
+
+        # check again, should fail
+        self.assertFalse(bucket.checkup(self.my_store_path))
+
+        # rebuild
+        bucket.build(self.my_store_path, False, False)
+
+        # check again, should pass
+        self.assertTrue(bucket.checkup(self.my_store_path))
+
+        # clean command
+        bucket.clean(self.my_store_path)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -95,9 +95,6 @@ class TestBuilder(unittest.TestCase):
         audit_results = bucket.full_audit(b"storj", self.my_store_path, height, True)
         self.assertEqual(audit_results, ans)
 
-        # clean command
-        bucket.clean(self.my_store_path)
-
     def test_builder_checkup(self):
         # generate shards for testing
         bucket = Builder(address_epsilon, my_shard_size, my_max_size)
@@ -112,9 +109,6 @@ class TestBuilder(unittest.TestCase):
 
         # check again, should fail
         self.assertFalse(bucket.checkup(self.my_store_path))
-
-        # clean command
-        bucket.clean(self.my_store_path)
 
     def test_build_rebuild(self):
         # generate shards for testing
@@ -133,9 +127,6 @@ class TestBuilder(unittest.TestCase):
 
         # check again, should pass
         self.assertTrue(bucket.checkup(self.my_store_path))
-
-        # clean command
-        bucket.clean(self.my_store_path)
 
     def test_build_rebuild(self):
         # generate shards for testing
@@ -165,6 +156,3 @@ class TestBuilder(unittest.TestCase):
         bucket.build(self.my_store_path, False, False, True)
         sha256_mod_file = partialhash.compute(path)
         self.assertEqual(sha256_org_file, sha256_mod_file)
-
-        # clean command
-        bucket.clean(self.my_store_path)

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -2,8 +2,8 @@ import os
 import shutil
 import unittest
 import tempfile
-import binascii
 import partialhash
+from datetime import datetime
 from dataserv_client.builder import Builder
 
 address_alpha = "12guBkWfVjiqBnu5yRdTseBB7wBM5WSWnm"
@@ -156,3 +156,21 @@ class TestBuilder(unittest.TestCase):
         bucket.build(self.my_store_path, False, False, True)
         sha256_mod_file = partialhash.compute(path)
         self.assertEqual(sha256_org_file, sha256_mod_file)
+
+    def test_build_cont(self):
+        max_size1 = 1024*1024*384
+        max_size2 = 1024*1024*128
+
+        # generate shards for testing
+        start_time = datetime.utcnow()
+        bucket = Builder(address_epsilon, my_shard_size, max_size1)
+        bucket.build(self.my_store_path, False, False)
+        end_delta = datetime.utcnow() - start_time
+
+        # should skip all shards and be faster
+        start_time2 = datetime.utcnow()
+        bucket = Builder(address_epsilon, my_shard_size, max_size2)
+        bucket.build(self.my_store_path, False, False)
+        end_delta2 = datetime.utcnow() - start_time2
+
+        self.assertTrue(end_delta2<end_delta)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -174,14 +174,14 @@ class TestClientBuild(AbstractTestSetup, unittest.TestCase):
         client = api.Client(address_pi, url=url, debug=True,
                             max_size=1024*1024*256)  # 256MB
         client.register()
-        hashes = client.build(cleanup=True)
-        self.assertTrue(len(hashes) == 2)
+        height = client.build(cleanup=True)
+        self.assertTrue(height == 2)
 
         client = api.Client(address_omicron, url=url, debug=True,
                             max_size=1024*1024*512)  # 512MB
         client.register()
-        hashes = client.build(cleanup=True)
-        self.assertTrue(len(hashes) == 4)
+        height = client.build(cleanup=True)
+        self.assertTrue(height == 4)
 
     def test_address_required(self):
         def callback():


### PR DESCRIPTION
## Changelog:
- Builds now skip files that have the proper seed name. This allows for users to continue builds, but will not work if files are modified or incomplete.
- Rebuild param can now be triggered to start the build from scratch.

## What is needed:
A cli call for --rebuild needs to added. 