### PR TITLE
Split client tests into unit tests and end-to-end tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,8 @@ setup(
     ],
     tests_require=[
         'coverage',
-        'coveralls'
+        'coveralls',
+        'mock'
     ],
     download_url=DOWNLOAD_URL,
     packages=find_packages(exclude=['dataserv_client.bin']),

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,4 +1,5 @@
 coverage
 coveralls
 dataserv
+mock
 -e git://github.com/cloudmatrix/esky.git#egg=esky

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,4 +1,3 @@
-import datetime
 import json
 import time
 import unittest
@@ -13,120 +12,41 @@ addresses = fixtures["addresses"]
 url = "http://127.0.0.1:5000"
 
 
-class AbstractTestSetup(object):
+class TestClientBase(object):
 
     def setUp(self):
         time.sleep(2)  # avoid collision
 
 
-class TestClientRegister(AbstractTestSetup, unittest.TestCase):
+class TestClientRegister(TestClientBase):
 
     def test_register(self):
         client = api.Client(addresses["alpha"], url=url)
         self.assertTrue(client.register())
 
-    def test_already_registered(self):
-        with self.assertRaises(exceptions.AddressAlreadyRegistered):
-            client = api.Client(addresses["beta"], url=url)
-            client.register()
-            client.register()
 
-    def test_invalid_address(self):
-        with self.assertRaises(exceptions.InvalidAddress):
-            client = api.Client("xyz", url=url)
-            client.register()
-
-    def test_invalid_farmer(self):
-        with self.assertRaises(exceptions.FarmerNotFound):
-            client = api.Client(addresses["nu"], url=url + "/xyz")
-            client.register()
-
-    def test_address_required(self):
-        with self.assertRaises(exceptions.AddressRequired):
-            api.Client().register()
-
-
-class TestClientPing(AbstractTestSetup, unittest.TestCase):
+class TestClientPing(TestClientBase):
 
     def test_ping(self):
         client = api.Client(addresses["gamma"], url=url)
         self.assertTrue(client.register())
         self.assertTrue(client.ping())
 
-    def test_invalid_address(self):
-        with self.assertRaises(exceptions.InvalidAddress):
-            client = api.Client("xyz", url=url)
-            client.ping()
 
-    def test_invalid_farmer(self):
-        with self.assertRaises(exceptions.FarmerNotFound):
-            client = api.Client(addresses["delta"], url=url + "/xyz")
-            client.ping()
-
-    def test_address_required(self):
-        with self.assertRaises(exceptions.AddressRequired):
-            api.Client().ping()
-
-
-class TestClientPoll(AbstractTestSetup, unittest.TestCase):
+class TestClientPoll(TestClientBase):
 
     def test_poll(self):
+        # TODO(mtlynch): Make a unit-test version of this that does not depend
+        # on an actual server.
         client = api.Client(addresses["zeta"], url=url)
         self.assertTrue(client.poll(register_address=True, limit=60))
 
-    def test_address_required(self):
-        with self.assertRaises(exceptions.AddressRequired):
-            api.Client().poll()
 
-
-class TestClientVersion(AbstractTestSetup, unittest.TestCase):
-
-    def test_version(self):
-        client = api.Client(url=url)
-        self.assertEqual(client.version(), api.__version__)
-
-
-class TestInvalidArgument(AbstractTestSetup, unittest.TestCase):
-
-    def test_invalid_retry_limit(self):
-        with self.assertRaises(exceptions.InvalidArgument):
-            api.Client(connection_retry_limit=-1)
-
-    def test_invalid_retry_delay(self):
-        with self.assertRaises(exceptions.InvalidArgument):
-            api.Client(connection_retry_delay=-1)
-
-
-class TestConnectionRetry(AbstractTestSetup, unittest.TestCase):
-
-    def test_no_retry(self):
-        def callback():
-            client = api.Client(address=addresses["kappa"],
-                                url="http://invalid.url",
-                                connection_retry_limit=0,
-                                connection_retry_delay=0)
-            client.register()
-        before = datetime.datetime.now()
-        self.assertRaises(exceptions.ConnectionError, callback)
-        after = datetime.datetime.now()
-        self.assertTrue(datetime.timedelta(seconds=15) > (after - before))
-
-    def test_default_retry(self):
-        def callback():
-            client = api.Client(address=addresses["kappa"],
-                                url="http://invalid.url",
-                                connection_retry_limit=5,
-                                connection_retry_delay=5)
-            client.register()
-        before = datetime.datetime.now()
-        self.assertRaises(exceptions.ConnectionError, callback)
-        after = datetime.datetime.now()
-        self.assertTrue(datetime.timedelta(seconds=25) < (after - before))
-
-
-class TestClientBuild(AbstractTestSetup, unittest.TestCase):
+class TestClientBuild(TestClientBase):
 
     def test_build(self):
+        # TODO(mtlynch): Make a unit-test version of this that does not depend
+        # on an actual server.
         client = api.Client(addresses["pi"], url=url, debug=True,
                             max_size=1024*1024*256)  # 256MB
         client.register()
@@ -139,12 +59,8 @@ class TestClientBuild(AbstractTestSetup, unittest.TestCase):
         generated = client.build(cleanup=True)
         self.assertTrue(len(generated) == 4)
 
-    def test_address_required(self):
-        with self.assertRaises(exceptions.AddressRequired):
-            api.Client().build()
 
-
-class TestClientCliArgs(AbstractTestSetup, unittest.TestCase):
+class TestClientCliArgs(TestClientBase):
 
     def test_poll(self):
         args = [

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,7 +1,8 @@
+import datetime
 import json
 import time
 import unittest
-import datetime
+
 from dataserv_client import cli
 from dataserv_client import api
 from dataserv_client import exceptions
@@ -25,28 +26,24 @@ class TestClientRegister(AbstractTestSetup, unittest.TestCase):
         self.assertTrue(client.register())
 
     def test_already_registered(self):
-        def callback():
+        with self.assertRaises(exceptions.AddressAlreadyRegistered):
             client = api.Client(addresses["beta"], url=url)
             client.register()
             client.register()
-        self.assertRaises(exceptions.AddressAlreadyRegistered, callback)
 
     def test_invalid_address(self):
-        def callback():
+        with self.assertRaises(exceptions.InvalidAddress):
             client = api.Client("xyz", url=url)
             client.register()
-        self.assertRaises(exceptions.InvalidAddress, callback)
 
     def test_invalid_farmer(self):
-        def callback():
+        with self.assertRaises(exceptions.FarmerNotFound):
             client = api.Client(addresses["nu"], url=url + "/xyz")
             client.register()
-        self.assertRaises(exceptions.FarmerNotFound, callback)
 
     def test_address_required(self):
-        def callback():
+        with self.assertRaises(exceptions.AddressRequired):
             api.Client().register()
-        self.assertRaises(exceptions.AddressRequired, callback)
 
 
 class TestClientPing(AbstractTestSetup, unittest.TestCase):
@@ -57,21 +54,18 @@ class TestClientPing(AbstractTestSetup, unittest.TestCase):
         self.assertTrue(client.ping())
 
     def test_invalid_address(self):
-        def callback():
+        with self.assertRaises(exceptions.InvalidAddress):
             client = api.Client("xyz", url=url)
             client.ping()
-        self.assertRaises(exceptions.InvalidAddress, callback)
 
     def test_invalid_farmer(self):
-        def callback():
+        with self.assertRaises(exceptions.FarmerNotFound):
             client = api.Client(addresses["delta"], url=url + "/xyz")
             client.ping()
-        self.assertRaises(exceptions.FarmerNotFound, callback)
 
     def test_address_required(self):
-        def callback():
+        with self.assertRaises(exceptions.AddressRequired):
             api.Client().ping()
-        self.assertRaises(exceptions.AddressRequired, callback)
 
 
 class TestClientPoll(AbstractTestSetup, unittest.TestCase):
@@ -81,9 +75,8 @@ class TestClientPoll(AbstractTestSetup, unittest.TestCase):
         self.assertTrue(client.poll(register_address=True, limit=60))
 
     def test_address_required(self):
-        def callback():
+        with self.assertRaises(exceptions.AddressRequired):
             api.Client().poll()
-        self.assertRaises(exceptions.AddressRequired, callback)
 
 
 class TestClientVersion(AbstractTestSetup, unittest.TestCase):
@@ -96,14 +89,12 @@ class TestClientVersion(AbstractTestSetup, unittest.TestCase):
 class TestInvalidArgument(AbstractTestSetup, unittest.TestCase):
 
     def test_invalid_retry_limit(self):
-        def callback():
+        with self.assertRaises(exceptions.InvalidArgument):
             api.Client(connection_retry_limit=-1)
-        self.assertRaises(exceptions.InvalidArgument, callback)
 
     def test_invalid_retry_delay(self):
-        def callback():
+        with self.assertRaises(exceptions.InvalidArgument):
             api.Client(connection_retry_delay=-1)
-        self.assertRaises(exceptions.InvalidArgument, callback)
 
 
 class TestConnectionRetry(AbstractTestSetup, unittest.TestCase):
@@ -149,9 +140,8 @@ class TestClientBuild(AbstractTestSetup, unittest.TestCase):
         self.assertTrue(len(generated) == 4)
 
     def test_address_required(self):
-        def callback():
+        with self.assertRaises(exceptions.AddressRequired):
             api.Client().build()
-        self.assertRaises(exceptions.AddressRequired, callback)
 
 
 class TestClientCliArgs(AbstractTestSetup, unittest.TestCase):
@@ -179,12 +169,11 @@ class TestClientCliArgs(AbstractTestSetup, unittest.TestCase):
         self.assertTrue(cli.main(args))
 
     def test_no_command_error(self):
-        def callback():
+        with self.assertRaises(SystemExit):
             cli.main(["--address=" + addresses["lambda"]])
-        self.assertRaises(SystemExit, callback)
 
     def test_input_error(self):
-        def callback():
+        with self.assertRaises(ValueError):
             cli.main([
                 "--address=" + addresses["mu"],
                 "--url=" + url,
@@ -193,12 +182,10 @@ class TestClientCliArgs(AbstractTestSetup, unittest.TestCase):
                 "--delay=5",
                 "--limit=xyz"
             ])
-        self.assertRaises(ValueError, callback)
 
     def test_api_error(self):
-        def callback():
+        with self.assertRaises(exceptions.InvalidAddress):
             cli.main(["--address=xyz", "--url=" + url, "register"])
-        self.assertRaises(exceptions.InvalidAddress, callback)
 
 
 if __name__ == '__main__':

--- a/tests/test_client_unit.py
+++ b/tests/test_client_unit.py
@@ -1,0 +1,144 @@
+import json
+import unittest
+import urllib
+
+import mock
+
+from dataserv_client import api
+from dataserv_client import exceptions
+
+
+fixtures = json.load(open("tests/fixtures.json"))
+_MOCK_ADDRESS = fixtures["addresses"]["alpha"]
+_MOCK_SERVER_URL = "http://1.2.3.4:5678"
+
+
+class MockHTTPError(urllib.error.HTTPError):
+
+    def __init__(self, code):
+        self.code = code
+
+
+class MockURLError(urllib.error.URLError):
+
+    def __init__(self):
+        pass
+
+
+class TestClient(unittest.TestCase):
+
+    def setUp(self):
+        urlopen_patch = mock.patch.object(urllib.request, "urlopen",
+                                          autospec=True)
+        self.addCleanup(urlopen_patch.stop)
+        urlopen_patch.start()
+
+        self.client = api.Client(_MOCK_ADDRESS, url=_MOCK_SERVER_URL)
+
+
+class TestClientRegister(TestClient):
+
+    def test_register(self):
+        urllib.request.urlopen.return_value.code = 200
+        self.assertTrue(self.client.register())
+        urllib.request.urlopen.assert_called_once_with(
+            _MOCK_SERVER_URL + "/api/register/" + _MOCK_ADDRESS)
+
+    def test_already_registered(self):
+        urllib.request.urlopen.side_effect = MockHTTPError(409)
+        with self.assertRaises(exceptions.AddressAlreadyRegistered):
+            self.client.register()
+        urllib.request.urlopen.assert_called_once_with(
+            _MOCK_SERVER_URL + "/api/register/" + _MOCK_ADDRESS)
+
+    def test_invalid_address(self):
+        urllib.request.urlopen.side_effect = MockHTTPError(400)
+        with self.assertRaises(exceptions.InvalidAddress):
+            self.client.register()
+        urllib.request.urlopen.assert_called_once_with(
+            _MOCK_SERVER_URL + "/api/register/" + _MOCK_ADDRESS)
+
+    def test_invalid_farmer(self):
+        urllib.request.urlopen.side_effect = MockHTTPError(404)
+        with self.assertRaises(exceptions.FarmerNotFound):
+            self.client.register()
+        urllib.request.urlopen.assert_called_once_with(
+            _MOCK_SERVER_URL + "/api/register/" + _MOCK_ADDRESS)
+
+    def test_address_required(self):
+        with self.assertRaises(exceptions.AddressRequired):
+            api.Client().register()
+        self.assertFalse(urllib.request.urlopen.called)
+
+
+class TestClientPing(TestClient):
+
+    def test_ping(self):
+        urllib.request.urlopen.return_value.code = 200
+        self.assertTrue(self.client.ping())
+        urllib.request.urlopen.assert_called_once_with(
+            _MOCK_SERVER_URL + "/api/ping/" + _MOCK_ADDRESS)
+
+    def test_invalid_address(self):
+        urllib.request.urlopen.side_effect = MockHTTPError(400)
+        with self.assertRaises(exceptions.InvalidAddress):
+            self.client.ping()
+        urllib.request.urlopen.assert_called_once_with(
+            _MOCK_SERVER_URL + "/api/ping/" + _MOCK_ADDRESS)
+
+    def test_invalid_farmer(self):
+        urllib.request.urlopen.side_effect = MockHTTPError(404)
+        with self.assertRaises(exceptions.FarmerNotFound):
+            self.client.ping()
+        urllib.request.urlopen.assert_called_once_with(
+            _MOCK_SERVER_URL + "/api/ping/" + _MOCK_ADDRESS)
+
+    def test_address_required(self):
+        with self.assertRaises(exceptions.AddressRequired):
+            api.Client().ping()
+        self.assertFalse(urllib.request.urlopen.called)
+
+
+class TestConnectionRetry(TestClient):
+
+    def test_invalid_retry_limit(self):
+        with self.assertRaises(exceptions.InvalidArgument):
+            api.Client(connection_retry_limit=-1)
+
+    def test_invalid_retry_delay(self):
+        with self.assertRaises(exceptions.InvalidArgument):
+            api.Client(connection_retry_delay=-1)
+
+    @mock.patch("time.sleep")
+    def test_no_retry(self, mock_sleep):
+        urllib.request.urlopen.side_effect = MockURLError()
+        client = api.Client(_MOCK_ADDRESS, url=_MOCK_SERVER_URL,
+                            connection_retry_limit=0,
+                            connection_retry_delay=0)
+        with self.assertRaises(exceptions.ConnectionError):
+            client.register()
+        self.assertTrue(urllib.request.urlopen.called)
+        self.assertFalse(mock_sleep.called)
+
+    @mock.patch("time.sleep")
+    def test_default_retry(self, mock_sleep):
+        urllib.request.urlopen.side_effect = MockURLError()
+        client = api.Client(_MOCK_ADDRESS, url=_MOCK_SERVER_URL,
+                            connection_retry_limit=5, connection_retry_delay=5)
+        with self.assertRaises(exceptions.ConnectionError):
+            client.register()
+        self.assertEqual(6, urllib.request.urlopen.call_count,
+                         "Expect 1 call + 5 retries = 6 calls")
+        mock_sleep.assert_has_calls([mock.call(5), mock.call(5), mock.call(5),
+                                     mock.call(5), mock.call(5)])
+
+
+class TestClientBuild(TestClient):
+
+    def test_address_required(self):
+        with self.assertRaises(exceptions.AddressRequired):
+            api.Client().build()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_client_unit.py
+++ b/tests/test_client_unit.py
@@ -25,7 +25,7 @@ class MockURLError(urllib.error.URLError):
         pass
 
 
-class TestClient(unittest.TestCase):
+class TestClientBase(unittest.TestCase):
 
     def setUp(self):
         urlopen_patch = mock.patch.object(urllib.request, "urlopen",
@@ -36,7 +36,7 @@ class TestClient(unittest.TestCase):
         self.client = api.Client(_MOCK_ADDRESS, url=_MOCK_SERVER_URL)
 
 
-class TestClientRegister(TestClient):
+class TestClientRegister(TestClientBase):
 
     def test_register(self):
         urllib.request.urlopen.return_value.code = 200
@@ -71,7 +71,7 @@ class TestClientRegister(TestClient):
         self.assertFalse(urllib.request.urlopen.called)
 
 
-class TestClientPing(TestClient):
+class TestClientPing(TestClientBase):
 
     def test_ping(self):
         urllib.request.urlopen.return_value.code = 200
@@ -99,7 +99,7 @@ class TestClientPing(TestClient):
         self.assertFalse(urllib.request.urlopen.called)
 
 
-class TestConnectionRetry(TestClient):
+class TestConnectionRetry(TestClientBase):
 
     def test_invalid_retry_limit(self):
         with self.assertRaises(exceptions.InvalidArgument):
@@ -133,7 +133,7 @@ class TestConnectionRetry(TestClient):
                                      mock.call(5), mock.call(5)])
 
 
-class TestClientBuild(TestClient):
+class TestClientBuild(TestClientBase):
 
     def test_address_required(self):
         with self.assertRaises(exceptions.AddressRequired):


### PR DESCRIPTION
The client tests are very slow to run and have external dependencies on a
running dataserv server.

This change splits up the client tests into end-to-end tests and unit tests,
where unit tests have no dependencies on external processes or global state.

The end-to-end tests exercise client-server interaction, but do not test
scenarios that are client or server focused. For example, there is no end to
end tests for double-registration of the same address because this is covered
by unit tests in both dataserv-client and dataserv (server). The end to end
tests are mainly positive tests of successful interaction between client and
server.

Also does some minor cleanup of the test code (removes multiple inheritance,
switches to context handler version of assertRaises).
