### PR TITLE
Refactoring out a client web API wrapper

### DIFF
--- a/dataserv_client/api.py
+++ b/dataserv_client/api.py
@@ -83,7 +83,8 @@ class Client(object):
             if first or set_height or last:
                 self._api_client.height(height)
 
-        bldr = builder.Builder(self.address, common.SHARD_SIZE, self.max_size,
+        bldr = builder.Builder(self._api_client.client_address(),
+                               common.SHARD_SIZE, self.max_size,
                                on_generate_shard=_on_generate_shard)
         generated = bldr.build(self.store_path, debug=self.debug,
                                cleanup=cleanup, rebuild=rebuild)

--- a/dataserv_client/api.py
+++ b/dataserv_client/api.py
@@ -83,7 +83,6 @@ class Client(object):
             if first or set_height or last:
                 self._api_client.height(height)
 
-        self._ensure_address_given()
         bldr = builder.Builder(self.address, common.SHARD_SIZE, self.max_size,
                                on_generate_shard=_on_generate_shard)
         generated = bldr.build(self.store_path, debug=self.debug,

--- a/dataserv_client/api.py
+++ b/dataserv_client/api.py
@@ -2,28 +2,19 @@
 
 from future.standard_library import install_aliases
 install_aliases()
-
+import datetime
+from datetime import timedelta
 import os
 import time
-import json
-import socket
-import urllib
-import urllib.error
-import urllib.request
-from btctxstore import BtcTxStore
-from email.utils import formatdate
-from datetime import datetime
-from datetime import timedelta
-from time import mktime
-from http.client import HTTPException
+
 from dataserv_client import __version__
+from dataserv_client import api_client
 from dataserv_client import builder
 from dataserv_client import common
 from dataserv_client import deserialize
-from dataserv_client import exceptions
 
 
-_now = datetime.now
+_now = datetime.datetime.now
 
 
 class Client(object):
@@ -33,114 +24,42 @@ class Client(object):
                  store_path=common.DEFAULT_STORE_PATH,
                  connection_retry_limit=common.DEFAULT_CONNECTION_RETRY_LIMIT,
                  connection_retry_delay=common.DEFAULT_CONNECTION_RETRY_DELAY):
+        retry_limit = deserialize.positive_integer(
+            connection_retry_limit)
+        retry_delay = deserialize.positive_integer(
+            connection_retry_delay)
+        self._api_client = api_client.ApiClient(url, wif, retry_limit,
+                                                retry_delay)
 
-        self.server_address = None
-        self.connection_retry_limit = deserialize.positive_integer(
-            connection_retry_limit
-        )
-        self.connection_retry_delay = deserialize.positive_integer(
-            connection_retry_delay
-        )
-        self.url = url  # TODO validate
         self.debug = debug  # TODO validate
         self.max_size = deserialize.byte_count(max_size)
         self.store_path = os.path.realpath(store_path)
-
-        self.blockchain = BtcTxStore()  # FIXME pass testnet and dryrun options
-
-        # set wif and address
-        if wif and not self.blockchain.validate_key(wif):
-            raise exceptions.InvalidWif(wif)
-        self.wif = wif
-        self.address = self.blockchain.get_address(wif) if wif else None
 
         # ensure storage dir exists
         if not os.path.exists(self.store_path):
             os.makedirs(self.store_path)
 
-    def _ensure_address_given(self):
-        if not self.address:  # TODO ensure address is valid
-            raise exceptions.AddressRequired()
-
     def version(self):
         print(__version__)
         return __version__
 
-    def _get_node_address(self):
-        if not self.server_address:
-            data = self._url_query('/api/address', authenticate=False)
-            data = json.loads(data.decode("utf-8"))
-            self.server_address = data["address"]  # TODO validate address
-        return self.server_address
-
-    def _create_authentication_headers(self):
-        blockchain = BtcTxStore()
-        header_date = formatdate(timeval=mktime(datetime.now().timetuple()),
-                                 localtime=True, usegmt=True)
-        message = self._get_node_address() + " " + header_date
-        header_authorization = blockchain.sign_unicode(self.wif, message)
-        return {"Date": header_date, "Authorization": header_authorization}
-
-    def _url_query(self, api_call, retries=0, authenticate=True):
-        try:
-            if self.debug:
-                print("Query url: " + self.url + api_call)
-            q = urllib.request.Request(self.url + api_call)
-            if self.wif and authenticate:
-                headers = self._create_authentication_headers()
-                q.add_header("Date", headers["Date"])
-                q.add_header("Authorization", headers["Authorization"])
-            response = urllib.request.urlopen(q)
-            if response.code == 200:
-                return response.read()
-
-            # unreachable code
-            return False  # pragma: no cover
-
-        except urllib.error.HTTPError as e:
-            if e.code == 409:
-                raise exceptions.AddressAlreadyRegistered(self.address,
-                                                          self.url)
-            elif e.code == 404:
-                raise exceptions.FarmerNotFound(self.url)
-            elif e.code == 400:
-                raise exceptions.InvalidAddress(self.address)
-            elif e.code == 500:  # pragma: no cover
-                raise exceptions.FarmerError(self.url)  # pragma: no cover
-            else:
-                raise e  # pragma: no cover
-        except HTTPException:
-            self._handle_connection_error(api_call, retries, authenticate)
-        except urllib.error.URLError:
-            self._handle_connection_error(api_call, retries, authenticate)
-        except socket.error:
-            self._handle_connection_error(api_call, retries, authenticate)
-
-    def _handle_connection_error(self, api_call, retries, authenticate):
-        if retries >= self.connection_retry_limit:
-            raise exceptions.ConnectionError(self.url)
-        time.sleep(self.connection_retry_delay)
-        return self._url_query(api_call, retries + 1, authenticate)
-
     def register(self):
         """Attempt to register the config address."""
-        self._ensure_address_given()
-        registered = self._url_query("/api/register/{0}".format(self.address))
-        if registered:
-            print("Address {0} now registered on {1}.".format(self.address,
-                                                              self.url))
-        return registered
+        self._api_client.register()
+        print("Address {0} now registered on {1}.".format(
+            self._api_client.client_address(), self._api_client.server_url()))
+        return True
 
     def ping(self):
         """Attempt keep-alive with the server."""
-        self._ensure_address_given()
-        print("Pinging {0} with address {1}.".format(self.url, self.address))
-        return self._url_query("/api/ping/{0}".format(self.address))
+        print("Pinging {0} with address {1}.".format(
+            self._api_client.server_url(), self._api_client.client_address()))
+        self._api_client.ping()
+        return True
 
     def poll(self, register_address=False, delay=common.DEFAULT_DELAY,
              limit=None):
         """TODO doc string"""
-        self._ensure_address_given()
         stop_time = _now() + timedelta(seconds=int(limit)) if limit else None
 
         if register_address:
@@ -155,14 +74,14 @@ class Client(object):
 
     def build(self, cleanup=False, rebuild=False):
         """TODO doc string"""
-        self._ensure_address_given()
 
         def on_generate_shard(height, seed, file_hash):
-            self._url_query('/api/height/{0}/{1}'.format(self.address, height))
-        bldr = builder.Builder(self.address, common.SHARD_SIZE, self.max_size,
+            self._api_client.height(height)
+        bldr = builder.Builder(self._api_client.client_address(),
+                               common.SHARD_SIZE, self.max_size,
                                on_generate_shard=on_generate_shard)
         generated = bldr.build(self.store_path, debug=self.debug,
                                cleanup=cleanup, rebuild=rebuild)
         height = len(generated)
-        self._url_query('/api/height/{0}/{1}'.format(self.address, height))
+        self._api_client.height(height)
         return generated

--- a/dataserv_client/api_client.py
+++ b/dataserv_client/api_client.py
@@ -1,0 +1,110 @@
+import datetime
+import email.utils
+import json
+import http.client
+import socket
+import time
+import urllib
+import urllib.error
+import urllib.request
+
+import btctxstore
+
+from dataserv_client import exceptions
+
+
+class ApiClient(object):
+
+    def __init__(self, server_url, wif, connection_retry_limit,
+                 connection_retry_delay):
+        self._server_url = server_url
+        self._server_address = None
+        self._connection_retry_limit = connection_retry_limit
+        self._connection_retry_delay = connection_retry_delay
+
+        # FIXME pass testnet and dryrun options
+        self._blockchain = btctxstore.BtcTxStore()
+        # set wif and address
+        if wif and not self._blockchain.validate_key(wif):
+            raise exceptions.InvalidWif(wif)
+        self._wif = wif
+        if wif:
+            self._client_address = self._blockchain.get_address(wif)
+        else:
+            self._client_address = None
+        if not self._client_address:
+            raise exceptions.AddressRequired()
+
+    def _url_query(self, api_path, retries=0, authenticate=True):
+        try:
+            req = urllib.request.Request(self._server_url + api_path)
+            if self._wif and authenticate:
+                headers = self._create_authentication_headers()
+                req.add_header("Date", headers["Date"])
+                req.add_header("Authorization", headers["Authorization"])
+            response = urllib.request.urlopen(req)
+            if response.code == 200:
+                return response.read()
+        except urllib.error.HTTPError as e:
+            if e.code == 409:
+                raise exceptions.AddressAlreadyRegistered(self._client_address,
+                                                          self._server_url)
+            elif e.code == 404:
+                raise exceptions.FarmerNotFound(self._server_url)
+            elif e.code == 400:
+                raise exceptions.InvalidAddress(self._client_address)
+            elif e.code == 500:  # pragma: no cover
+                raise exceptions.FarmerError(self._server_url)
+            else:
+                raise e  # pragma: no cover
+        except http.client.HTTPException:
+            self._handle_connection_error(api_path, retries, authenticate)
+        except urllib.error.URLError:
+            self._handle_connection_error(api_path, retries, authenticate)
+        except socket.error:
+            self._handle_connection_error(api_path, retries, authenticate)
+
+    def _get_node_address(self):
+        if not self._server_address:
+            # TODO validate address
+            self._server_address = self.address()
+        return self._server_address
+
+    def _create_authentication_headers(self):
+        header_date = email.utils.formatdate(
+            timeval=time.mktime(datetime.datetime.now().timetuple()),
+            localtime=True, usegmt=True)
+        message = self._get_node_address() + " " + header_date
+        header_authorization = self._blockchain.sign_unicode(
+            self._wif, message)
+        return {"Date": header_date,
+                "Authorization": header_authorization}
+
+    def _handle_connection_error(self, api_path, retries, authenticate):
+        if retries >= self._connection_retry_limit:
+            raise exceptions.ConnectionError(self._server_url)
+        time.sleep(self._connection_retry_delay)
+        return self._url_query(api_path, retries + 1, authenticate)
+
+    def server_url(self):
+        return self._server_url
+
+    def client_address(self):
+        return self._client_address
+
+    def address(self):
+        data = self._url_query("/api/address", authenticate=False)
+        return json.loads(data.decode("utf-8"))["address"]
+
+    def register(self):
+        """Attempt to register this client address."""
+        return self._url_query("/api/register/%s" % self._client_address)
+
+    def ping(self):
+        """Send a heartbeat message for this client address."""
+        return self._url_query("/api/ping/%s" % self._client_address)
+
+    def height(self, height):
+        """Set the height claim for this client address."""
+        return self._url_query('/api/height/%s/%s' % (self._client_address,
+                                                      height))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -92,13 +92,6 @@ class TestClientPoll(AbstractTestSetup, unittest.TestCase):
         self.assertRaises(exceptions.AddressRequired, callback)
 
 
-class TestClientVersion(AbstractTestSetup, unittest.TestCase):
-
-    def test_version(self):
-        client = api.Client(url=url)
-        self.assertEqual(client.version(), api.__version__)
-
-
 class TestInvalidArgument(AbstractTestSetup, unittest.TestCase):
 
     def test_invalid_retry_limit(self):


### PR DESCRIPTION
Splitting out a client API wrapper for the Client class so that we can improve
testability by unit testing the Client code separately from a live server and
more easily test the API code without being tied to the additional complexity
of Client.

Removes the version test because it does not provide any value (the unit test
reimplements the same code as the function under test).
