### PR TITLE
Builds shards in parallel

### DIFF
--- a/dataserv_client/api.py
+++ b/dataserv_client/api.py
@@ -177,7 +177,8 @@ class Client(object):
             time.sleep(int(delay))
 
     def build(self, cleanup=False, rebuild=False,
-              set_height_interval=common.DEFAULT_SET_HEIGHT_INTERVAL):
+              set_height_interval=common.DEFAULT_SET_HEIGHT_INTERVAL,
+              num_cores=common.DEFAULT_NUMCORES):
         """
         Generate test files deterministically based on address.
 
@@ -191,9 +192,10 @@ class Client(object):
         )
         cleanup = deserialize.flag(cleanup)
         rebuild = deserialize.flag(rebuild)
+        num_cores = deserialize.positive_nonzero_integer(num_cores)
 
         self._init_messenger()
-        logger.info("Starting build")
+        logger.info("Starting build with {} cores".format(num_cores))
 
         on_generate_shard = partial(
             _on_generate_shard,
@@ -206,7 +208,7 @@ class Client(object):
                                debug=self.debug,
                                on_generate_shard=on_generate_shard)
         generated = bldr.build(self.store_path, cleanup=cleanup,
-                               rebuild=rebuild)
+                               rebuild=rebuild, num_cores=num_cores)
 
         logger.info("Build finished")
         return generated

--- a/dataserv_client/builder.py
+++ b/dataserv_client/builder.py
@@ -111,7 +111,7 @@ class Builder:
             logger.info("Resuming from height {0}".format(index + 1))
         return enum_seeds[index:]
 
-    def build(self, store_path, cleanup=False, rebuild=False):
+    def build(self, store_path, cleanup=False, rebuild=False, num_cores=1):
         """
         Fill the farmer with data up to their max.
 
@@ -130,7 +130,7 @@ class Builder:
             store_path=store_path,
             cleanup=cleanup
         )
-        with ProcessPoolExecutor(max_workers=4) as executor:
+        with ProcessPoolExecutor(max_workers=num_cores) as executor:
             g = executor.map(worker, enum_seeds)
         generated = dict(list(g))
 

--- a/dataserv_client/cli.py
+++ b/dataserv_client/cli.py
@@ -107,6 +107,13 @@ def _add_build(command_parser):
         help="Interval at which to set height (default: {0}).".format(default)
     )
 
+    # specify the number of shards to build in parallel
+    default = common.DEFAULT_NUMCORES
+    build_parser.add_argument(
+        "--num_cores", default=default,
+        help="Number shards to build in parallel"
+    )
+
 
 def _add_farm(command_parser):
     farm_parser = command_parser.add_parser(

--- a/dataserv_client/common.py
+++ b/dataserv_client/common.py
@@ -14,6 +14,7 @@ DEFAULT_SET_HEIGHT_INTERVAL = 25
 SHARD_SIZE = 1024 * 1024 * 128  # 128 MB
 DEFAULT_MAX_SIZE = 1024 * 1024 * 1024  # 1 GB
 DEFAULT_STORE_PATH = os.path.join(DEFAULT_APP_HOME, "store")
+DEFAULT_NUMCORES = 1
 
 
 # connection retry
@@ -21,5 +22,5 @@ DEFAULT_CONNECTION_RETRY_LIMIT = 120  # 120 * 30sec = 1 hour
 DEFAULT_CONNECTION_RETRY_DELAY = 30
 
 
-_log_format = "%(levelname)s %(name)s %(lineno)d: %(message)s"      
+_log_format = "%(levelname)s %(name)s %(lineno)d: %(message)s"
 logging.basicConfig(format=_log_format, level=logging.DEBUG)


### PR DESCRIPTION
This pull request adds the options to specify a certain number of cores to build shards in parallel.
It leverages the python3 specific library concurrent.future, and thus needs picklable objects. Let me know if I should put the helper functions somewhere else.

I did not add tests, as I'm terrible at this. Let me know if they are a hard requirement and I'll give my best shot.
